### PR TITLE
Upgrade build.gradle to point to correct repositories

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compile 'com.github.owncloud:android-library:oc-android-library-0.9.8'
     compile 'commons-io:commons-io:2.4'
 
-    compile('com.afollestad.material-dialogs:core:0.8.1.0@aar') {
+    compile('com.github.afollestad.material-dialogs:core:0.8.1.0@aar') {
         transitive = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,11 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://jitpack.io" }
+        mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 


### PR DESCRIPTION
This ensures Android Studio is able to successfully fetch the dependencies for this project.

I'm not experienced enough in Android development to know whether this fix will work everywhere, or whether it is tightly linked to my current Android Studio version (4.1.3).
I'll let you decide whether this deserves being merged in master or not :)

Thanks for MyOwnNotes anyway. Even if it is now unmaintained, it is still working pretty well!